### PR TITLE
add cython as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
 
 	ext_modules=cythonize(extensions),
 	python_requires=">=2.7",
+	install_requires=["cython"],
 	use_2to3=False,
 	zip_safe=False,
 )


### PR DESCRIPTION
I've just stumbled across this problem: my DockerFile now fails to install it due to the lack of `cython`. If I obviously can manually add `cython`, wouldn't be easier to just add `cython` as a dependency of `metrohash-python` ? It does work fine with `pip`.